### PR TITLE
Update EgnyteAdaptor

### DIFF
--- a/src/EgnyteAdapter.php
+++ b/src/EgnyteAdapter.php
@@ -151,7 +151,7 @@ class EgnyteAdapter extends AbstractAdapter
     {
         $md = $this->getMetadata($path);
 
-        if( isset($md['checksum']) ){
+        if( isset($md['timestamp']) ){
             return $md;
         }
 


### PR DESCRIPTION
When using  EgnyteAdaptor with a stream wrapper and renaming a file the 'has' check on the subdirectory of the destination was returning false due to the metadata not containing a checksum, which is not expected to be returned for a directory.